### PR TITLE
Pinned cbang, updated .gitignore, bumped version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,10 @@ __pycache__
 *.deb
 *.zip
 /rpi-share
+/rpi-root
 /package-lock.json
+/src/bbserial/linux-rpi-raspberrypi-kernel*
+/src/bbserial/raspberrypi-kernel*
 
 *.elf
 *.hex

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ $(GPLAN_MOD): $(GPLAN_IMG)
 	./scripts/gplan-init-build.sh
 	git -C rpi-share/cbang fetch
 	git -C rpi-share/cbang reset --hard FETCH_HEAD
+	git -C rpi-share/cbang checkout 18f1e963107ef26abe750c023355a5c40dd07853
 	git -C rpi-share/camotics fetch
 	git -C rpi-share/camotics reset --hard FETCH_HEAD
 	git -C rpi-share/camotics checkout ec876c80d20fc19837133087cef0c447df5a939d

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbctrl",
-  "version": "1.0.6",
+  "version": "1.0.7b0",
   "homepage": "https://onefinitycnc.com/",
   "repository": "https://github.com/OneFinityCNC/onefinity",
   "license": "GPL-3.0+",

--- a/src/py/bbctrl/Config.py
+++ b/src/py/bbctrl/Config.py
@@ -137,7 +137,9 @@ class Config(object):
 
 
     def upgrade(self, config):
-        version = tuple(map(int, config['version'].split('.')))
+        version = config['version']
+        version = version.split('b')[0] # Strip off any "beta" suffix
+        version = tuple(map(int, version.split('.'))) # Break it into a tuple of integers
 
         if version < (0, 2, 4):
             for motor in config['motors']:
@@ -177,7 +179,7 @@ class Config(object):
         self._update(config, False)
 
         with open(self.ctrl.get_path('config.json'), 'w') as f:
-            json.dump(config, f)
+            json.dump(config, f, indent=2)
 
         os.sync()
 


### PR DESCRIPTION
* I added a few more things to .gitignore - mostly artifacts from the gplan build process.
* Bumped the version in package.json to 1.07b0.  I would have used 1.0.7-beta.0, but the Python "setuptools" package insists that's not valid, and renames the output file - accepting its judgement was easier than trying to adapt the build.
* The version change forced me to adjust the code in Config.py to understand that the version number could contain "extra" things - the "b<n>" suffix.
* While I was in there, I also changed the serialization of the config.json file so it's human readable.