### PR TITLE
 "parallel build" flag for cbang/camotics builds

### DIFF
--- a/scripts/gplan-build.sh
+++ b/scripts/gplan-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
 cd /mnt/host
-scons -C cbang disable_local="re2 libevent"
+scons -j 8 -C cbang disable_local="re2 libevent"
 export CBANG_HOME="/mnt/host/cbang"
-scons -C camotics gplan.so with_gui=0 with_tpl=0
+scons -j 8 -C camotics gplan.so with_gui=0 with_tpl=0


### PR DESCRIPTION
This causes Scons to build 8 files at a time - appears to shorten the build time on a clean build of cbang and camotics.