### PR TITLE
Resize root filesystem, plus some housekeeping

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,5 +12,6 @@ include scripts/bbctrl.service
 include scripts/11-automount.rules
 include scripts/resize_root_fs.sh
 include scripts/resize2fs_once
+include scripts/bbctrl-logrotate
 recursive-include src/py/camotics *
 global-exclude .gitignore

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,9 +5,12 @@ include src/bbserial/bbserial.ko
 include scripts/avr109-flash.py
 include scripts/buildbotics.gc
 include scripts/xinitrc
+include scripts/Xresources
 include scripts/ratpoisonrc
 include scripts/rc.local
 include scripts/bbctrl.service
 include scripts/11-automount.rules
+include scripts/resize_root_fs.sh
+include scripts/resize2fs_once
 recursive-include src/py/camotics *
 global-exclude .gitignore

--- a/scripts/Xresources
+++ b/scripts/Xresources
@@ -1,0 +1,2 @@
+xterm*faceSize: 12
+xterm*faceName: DejaVu Sans Mono

--- a/scripts/bbctrl-logrotate
+++ b/scripts/bbctrl-logrotate
@@ -1,0 +1,8 @@
+/var/log/bbctrl.log {
+  rotate 4
+  weekly
+  compress
+  missingok
+  notifempty
+  copytruncate
+}

--- a/scripts/cron_d_reboot
+++ b/scripts/cron_d_reboot
@@ -1,0 +1,1 @@
+@reboot root run-parts  /etc/cron.reboot

--- a/scripts/cron_reboot_logrotate
+++ b/scripts/cron_reboot_logrotate
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+test -x /usr/sbin/logrotate || exit 0
+/usr/sbin/logrotate /etc/logrotate.conf

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,6 +146,13 @@ fi
 cp ./scripts/bbctrl-logrotate /etc/logrotate.d/bbctrl
 chown root:root /etc/logrotate.d/bbctrl
 
+# Ensure logrotate runs on every boot (for systems with no network, thus bad clock)
+if [ ! -e /etc/cron.d/reboot ]; then
+    cp ./scripts/cron_d_reboot /etc/cron.d/reboot
+    mkdir -p /etc/cron.reboot
+    cp ./scripts/cron_reboot_logrotate /etc/cron.reboot/logrotate
+fi
+
 ##########################################
 # Begin one-time cleanup tasks for 1.0.7
 ##########################################

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,7 +93,9 @@ if [ $? -ne 0 ]; then
     REBOOT=true
 fi
 
-# Install xinitrc
+# Install .Xresources & .xinitrc
+cp scripts/Xresources ~pi/.Xresources
+chown pi:pi ~pi/.Xresources
 cp scripts/xinitrc ~pi/.xinitrc
 chmod +x ~pi/.xinitrc
 chown pi:pi ~pi/.xinitrc
@@ -131,6 +133,13 @@ if $UPDATE_PY; then
     service bbctrl restart
     HTTP_DIR=$(find /usr/local/lib/ -type d -name "http")
     chmod 777 $HTTP_DIR
+fi
+
+# Expand the file system if necessary
+chmod +x ./scripts/resize_root_fs.sh
+./scripts/resize_root_fs.sh
+if [ $? -eq 0 ]; then
+    REBOOT=true
 fi
 
 sync

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -142,6 +142,40 @@ if [ $? -eq 0 ]; then
     REBOOT=true
 fi
 
+# Install our logrotate config
+cp ./scripts/bbctrl-logrotate /etc/logrotate.d/bbctrl
+chown root:root /etc/logrotate.d/bbctrl
+
+##########################################
+# Begin one-time cleanup tasks for 1.0.7
+##########################################
+
+# Delete the entire local Chromium configuration. Start clean.
+rm -rf /home/pi/.config/chromium
+
+# Get rid of some old files that were left behind
+rm -rf /home/pi/hostinfo.txt
+rm -rf /home/pi/ssidinfo.txt
+rm -rf /home/bbmc/bbctrl-1.0.0.tar.bz2
+rm -rf /home/bbmc/hostinfo.sh
+rm -rf /home/bbmc/index.html
+rm -rf /home/bbmc/favicon.ico
+
+# Force a logrotate to get everything into a known state
+logrotate -f /etc/logrotate.conf
+
+# Clean up the log directory - get rid of everything old
+rm -rf /var/log/*.gz
+rm -rf /var/log/*.1
+rm -rf /var/log/*.old
+rm -rf /var/log/bbctrl.2019*.install
+rm -rf /var/log/bbctrl.2020*.install
+rm -rf /var/log/bbctrl.log.*
+
+##########################################
+# End one-time cleanup tasks for 1.0.7
+##########################################
+
 sync
 
 if $REBOOT; then

--- a/scripts/ratpoisonrc
+++ b/scripts/ratpoisonrc
@@ -4,3 +4,4 @@ set fgcolor white
 
 unbind c
 bind c exec x-terminal-emulator -fg white -bg black
+bind C-c exec x-terminal-emulator -fg white -bg black

--- a/scripts/resize2fs_once
+++ b/scripts/resize2fs_once
@@ -1,0 +1,25 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          resize2fs_once
+# Required-Start:
+# Required-Stop:
+# Default-Start: 3
+# Default-Stop:
+# Short-Description: Resize the root filesystem to fill partition
+# Description:
+### END INIT INFO
+. /lib/lsb/init-functions
+case "$1" in
+  start)
+    log_daemon_msg "Starting resize2fs_once"
+    ROOT_DEV=$(findmnt / -o source -n) &&
+    resize2fs $ROOT_DEV &&
+    update-rc.d resize2fs_once remove &&
+    rm /etc/init.d/resize2fs_once &&
+    log_end_msg $?
+    ;;
+  *)
+    echo "Usage: $0 start" >&2
+    exit 3
+    ;;
+esac

--- a/scripts/resize_root_fs.sh
+++ b/scripts/resize_root_fs.sh
@@ -25,8 +25,6 @@ get_fs_resize_variables () {
 should_resize_root_partition() {
     get_fs_resize_variables
 
-    ( set -o posix ; set )
-   
     if [ "$BOOT_DEV_NAME" != "$ROOT_DEV_NAME" ]; then
         FAIL_REASON="Boot and root partitions are on different devices"
         return 1

--- a/scripts/resize_root_fs.sh
+++ b/scripts/resize_root_fs.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Used by the OneFinity firmware to determine if the root filesystem
+# needs to be enlarged to maximize usage of the SD card.
+#
+# The majority of this code originates from /usr/lib/raspi-config/init_resize.sh
+
+get_fs_resize_variables () {
+    ROOT_PART_DEV=$(findmnt / -o source -n)
+    ROOT_PART_NAME=$(echo "$ROOT_PART_DEV" | cut -d "/" -f 3)
+    ROOT_DEV_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
+    ROOT_DEV="/dev/${ROOT_DEV_NAME}"
+    ROOT_PART_NUM=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/partition")
+    BOOT_PART_DEV=$(findmnt /boot -o source -n)
+    BOOT_PART_NAME=$(echo "$BOOT_PART_DEV" | cut -d "/" -f 3)
+    BOOT_DEV_NAME=$(echo /sys/block/*/"${BOOT_PART_NAME}" | cut -d "/" -f 4)
+    ROOT_DEV_SIZE=$(cat "/sys/block/${ROOT_DEV_NAME}/size")
+    TARGET_END=$((ROOT_DEV_SIZE - 1))
+    PARTITION_TABLE=$(parted -m "$ROOT_DEV" unit s print | tr -d 's')
+    LAST_PART_NUM=$(echo "$PARTITION_TABLE" | tail -n 1 | cut -d ":" -f 1)
+    ROOT_PART_LINE=$(echo "$PARTITION_TABLE" | grep -e "^${ROOT_PART_NUM}:")
+    ROOT_PART_END=$(echo "$ROOT_PART_LINE" | cut -d ":" -f 3)
+}
+
+should_resize_root_partition() {
+    get_fs_resize_variables
+
+    ( set -o posix ; set )
+   
+    if [ "$BOOT_DEV_NAME" != "$ROOT_DEV_NAME" ]; then
+        FAIL_REASON="Boot and root partitions are on different devices"
+        return 1
+    fi
+
+    if [ "$ROOT_PART_NUM" -ne "$LAST_PART_NUM" ]; then
+        FAIL_REASON="Root partition should be last partition"
+        return 1
+    fi
+
+    if [ "$ROOT_PART_END" -gt "$TARGET_END" ]; then
+        FAIL_REASON="Root partition runs past the end of device"
+        echo $FAIL_REASON
+        return 1
+    fi
+
+    if [ ! -b "$ROOT_DEV" ] || [ ! -b "$ROOT_PART_DEV" ] || [ ! -b "$BOOT_PART_DEV" ] ; then
+        FAIL_REASON="Could not determine partitions"
+        return 1
+    fi
+
+    if [ "$ROOT_PART_END" -eq "$TARGET_END" ]; then
+        FAIL_REASON="Root partition is already expanded"
+        return 1
+    fi
+}
+
+if should_resize_root_partition; then
+    grep "init_resize" /boot/cmdline.txt >/dev/null
+    if [ $? -ne 0 ]; then
+        # On the next boot, init_resize.sh will:
+        #   Resize the root partition to use the rest of the SD card
+        #   Remove itself from /boot/cmdline.txt
+        #   Reboot the machine
+        sudo mount /boot -o rw,remount
+        sed -i 's/\(.*\)/\1 init=\/usr\/lib\/raspi-config\/init_resize.sh/' /boot/cmdline.txt
+    fi
+
+    # On the first boot after init_resize, resize2fs_once will:
+    #   Resize the root fs to fill its partition
+    #   Remove itself from the registered systemd services
+    #   Delete itself from the filesystem
+    #   Therefore, never run again
+    cp scripts/resize2fs_once /etc/init.d/resize2fs_once
+    chmod +x /etc/init.d/resize2fs_once
+    systemctl enable resize2fs_once
+
+    exit 0
+else
+    echo "Not resizing root partition: $FAIL_REASON"
+    exit 1
+fi

--- a/scripts/xinitrc
+++ b/scripts/xinitrc
@@ -14,6 +14,8 @@ while true; do
         sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' $PREFS
         sed -i 's/"exit_type":"Crashed"/"exit_type":"Normal"/' $PREFS
 
+        xrdb /home/pi/.Xresources
+
         # Start browser
         /usr/local/bin/browser --no-first-run --disable-infobars \
          --noerrdialogs --disable-3d-apis http://localhost/

--- a/src/py/bbctrl/Log.py
+++ b/src/py/bbctrl/Log.py
@@ -170,7 +170,7 @@ class Log(object):
         if self.path is None: return
         if self.f is not None: self.f.close()
         self._rotate(self.path)
-        self.f = open(self.path, 'w')
+        self.f = open(self.path, 'a')
         self.bytes_written = 0
 
 


### PR DESCRIPTION
- Checks to see if the filesystem needs to be expanded - if so, updates config to make it happen after the upgrade is complete.
- Implemented logrotate for the firmware's own log files.
- Changed the firmware's Log.py to open the log file in append mode, to fix an issue with logrotate - tons of nulls were being prepended to the log file after a rotate.
- Changed the background color of xterm to white on black, and a cleaner larger font - easier on the eyes.
- Added a drive-cleanup step to the installer - this is intended for only v1.0.7, and should be removed when work begins on 1.0.8.
